### PR TITLE
fix: use correct keys for cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "next",
     "build": "next build",
     "export": "next build && next export",
-    "start": "NODE_ENV=production node server.js",
+    "start": "node server.js",
     "postinstall": "next build"
   },
   "author": "",

--- a/server.js
+++ b/server.js
@@ -4,6 +4,8 @@ const LRUCache = require('lru-cache');
 
 require('dotenv').config();
 
+const CACHE_ENABLED = (process.env.CACHE_ENABLED === 'true') || false;
+
 const port = parseInt(process.env.WEBSITES_PORT, 10) || 3000;
 const dev = process.env.NODE_ENV !== 'production';
 const app = next({ dev });
@@ -59,7 +61,7 @@ async function renderAndCache(req, res) {
   const key = getCacheKey(req);
 
   // If we have a page in the cache, let's serve it
-  if (ssrCache.has(key)) {
+  if (ssrCache.has(key) && CACHE_ENABLED) {
     //console.log(`serving from cache ${key}`);
     res.setHeader('x-cache', 'HIT');
     res.send(ssrCache.get(key));
@@ -78,7 +80,9 @@ async function renderAndCache(req, res) {
     }
 
     // Let's cache this page
-    ssrCache.set(key, html);
+    if (CACHE_ENABLED) {
+      ssrCache.set(key, html);
+    }
 
     res.setHeader('x-cache', 'MISS');
     res.send(html);

--- a/server.js
+++ b/server.js
@@ -54,7 +54,7 @@ app.prepare().then(() => {
  * an immediate page change (e.g a locale stored in req.session)
  */
 function getCacheKey(req) {
-  return `${req.path}`;
+  return `${req.path}${JSON.stringify(req.query)}`;
 }
 
 async function renderAndCache(req, res) {


### PR DESCRIPTION
Cache keys are now saved with the query string parameters included, so that changing an option in the dropdown will fetch a new cached object (when available).