### PR TITLE
feat: remove api endpoint

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,7 +6,14 @@ require('dotenv').config();
 module.exports = withCSS(
   withSass({
     cssModules: true,
-    webpack(config) {
+
+    webpack(config, { isServer }) {
+      if (!isServer) {
+        config.node = {
+          fs: 'empty'
+        }
+      }
+
       config.module.rules.push({
         test: /\.(png|jpg|gif|svg|eot|ttf|woff|woff2)$/,
         use: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3794,6 +3794,11 @@
         "readable-stream": "^2.0.0"
       }
     },
+    "fs": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+      "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ="
+    },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -3827,7 +3832,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3845,11 +3851,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3862,15 +3870,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3973,7 +3984,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3983,6 +3995,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3995,17 +4008,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4022,6 +4038,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4094,7 +4111,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4104,6 +4122,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4179,7 +4198,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4209,6 +4229,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4226,6 +4247,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4264,11 +4286,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dotenv": "^8.1.0",
     "express": "^4.17.1",
     "file-saver": "^2.0.2",
+    "fs": "0.0.1-security",
     "highcharts": "^7.2.0",
     "highcharts-react-official": "^2.2.2",
     "id-icons": "git+https://github.com/smashmiek/id-icons.git",

--- a/server.js
+++ b/server.js
@@ -29,12 +29,6 @@ app.prepare().then(() => {
     handle(req, res);
   });
 
-  server.get('/api/*', (req, res) => {
-    /* serving _next static content using next.js handler */
-
-    handle(req, res);
-  });
-
   server.get('*', (req, res) => {
     /* serving page */
     return renderAndCache(req, res);

--- a/src/pages/[clientAlias]/population/api.ts
+++ b/src/pages/[clientAlias]/population/api.ts
@@ -1,16 +1,17 @@
 import _ from 'lodash';
 import { commClient, commDataEconomy } from '../../../server/dbConnection';
 
-const handle = async (req, res) => {
-  const { clientAlias } = req.query;
+const fetchData = async (filters) => {
+  const { clientAlias } = filters;
   const clients = await commClient.raw(ClientSQL);
   const client: any = clientFromAlias(clientAlias, clients);
   const navigation = await commClient.raw(MainNavigationSQL({ client }));
   const clientProducts = await commClient.raw(ClientProductsSQL({ client }));
 
-  res.json({ client, navigation, clientProducts });
+  return { client, navigation, clientProducts, filters };
 };
-export default handle;
+
+export default fetchData;
 
 const ignoreClients = _.isUndefined(process.env.IGNORE_CLIENTS)
   ? []

--- a/src/pages/[clientAlias]/population/index.tsx
+++ b/src/pages/[clientAlias]/population/index.tsx
@@ -1,7 +1,8 @@
 import fetch from 'isomorphic-unfetch';
 import { useRouter } from 'next/router';
-import Layout from '../../layouts/main';
-import { getPort } from '../../Utils';
+import Layout from '../../../layouts/main';
+import { getPort } from '../../../Utils';
+import fetchData from './api';
 
 const Population = ({ client, navigation, clientProducts, sitemapGroups }) => {
   const { clientAlias } = useRouter().query;
@@ -19,8 +20,8 @@ export default Population;
 
 Population.getInitialProps = async function({ query }) {
   const { clientAlias } = query;
-  const data = await fetch(
-    `http://localhost:${getPort()}/api/${clientAlias}/population`
-  ).then(res => res.json());
+  
+  const data = await fetchData({clientAlias})
+
   return data;
 };

--- a/src/pages/[clientAlias]/workers-field-of-qualification/api.ts
+++ b/src/pages/[clientAlias]/workers-field-of-qualification/api.ts
@@ -2,8 +2,9 @@ import _ from 'lodash';
 const knex = require('knex');
 import { commClient, commDataEconomy } from '../../../server/dbConnection';
 
-const handle = async (req, res) => {
-  const { clientAlias, Indkey, IGBMID, Sex } = req.query;
+const fetchData = async (filters) => {
+  const { clientAlias, Indkey, IGBMID, Sex } = filters;
+
   const client = await commClient
     .raw(ClientSQL({ clientAlias }))
     .then(res => res[0]);
@@ -27,7 +28,7 @@ const handle = async (req, res) => {
     })
   );
 
-  res.json({
+  return {
     title: 'Workers fields of qualification',
     client,
     tableData,
@@ -36,9 +37,12 @@ const handle = async (req, res) => {
     Sexes,
     navigation,
     clientProducts,
-    sitemapGroups
-  });
+    sitemapGroups,
+    filters
+  };
 };
+
+export default fetchData;
 
 const clientFromAlias = (clientAlias, clients) =>
   _.find(clients, { Alias: clientAlias });
@@ -46,8 +50,6 @@ const clientFromAlias = (clientAlias, clients) =>
 const ignoreClients = _.isUndefined(process.env.IGNORE_CLIENTS)
   ? []
   : process.env.IGNORE_CLIENTS.split(' ');
-
-export default handle;
 
 const ClientSQL = ({ clientAlias }) => `
   SELECT

--- a/src/pages/[clientAlias]/workers-field-of-qualification/index.tsx
+++ b/src/pages/[clientAlias]/workers-field-of-qualification/index.tsx
@@ -1,4 +1,3 @@
-import fetch from 'isomorphic-unfetch';
 import _ from 'lodash';
 import Router, { useRouter } from 'next/router';
 import qs from 'qs';
@@ -6,14 +5,15 @@ import {
   formatNumber,
   formatChangeNumber,
   formatShortDecimal,
-  getPort
-} from '../../Utils';
-import EntityTable from '../../components/table/EntityTable';
-import ControlPanel from '../../components/ControlPanel/ControlPanel';
+} from '../../../Utils';
+import EntityTable from '../../../components/table/EntityTable';
+import ControlPanel from '../../../components/ControlPanel/ControlPanel';
 import React from 'react';
-import Layout from '../../layouts/main';
-import EntityChart from '../../components/chart/EntityChart';
-import IsoChart from '../../components/isoChart/chart';
+import Layout from '../../../layouts/main';
+import EntityChart from '../../../components/chart/EntityChart';
+import IsoChart from '../../../components/isoChart/chart';
+
+import fetchData from './api'
 
 const LocalWorkerFieldsOfQualififcation = ({
   client,
@@ -118,15 +118,9 @@ LocalWorkerFieldsOfQualififcation.getInitialProps = async ({ query }) => {
     Sex: 3
   };
   const filters = { ...defaultFilters, ...query };
-  const { clientAlias } = query;
 
-  const res = await fetch(
-    `http://localhost:${getPort()}/api/${clientAlias}/workers-field-of-qualification?${qs.stringify(
-      filters
-    )}`
-  );
-  const data = await res.json();
-  data.filters = filters;
+  const data = await fetchData(filters);
+
   return data;
 };
 

--- a/src/server/dbConnection.ts
+++ b/src/server/dbConnection.ts
@@ -1,8 +1,8 @@
 import knex from 'knex';
 
-// require('dotenv').config({
-//   path: `.env.${process.env.NODE_ENV}`
-// });
+require('dotenv').config({
+  path: `.env.${process.env.NODE_ENV}`
+});
 
 const getScopedEnvVar = (scope, db_env_var) => {
   return (

--- a/src/server/dbConnection.ts
+++ b/src/server/dbConnection.ts
@@ -1,8 +1,8 @@
 import knex from 'knex';
 
-require('dotenv').config({
-  path: `.env.${process.env.NODE_ENV}`
-});
+// require('dotenv').config({
+//   path: `.env.${process.env.NODE_ENV}`
+// });
 
 const getScopedEnvVar = (scope, db_env_var) => {
   return (


### PR DESCRIPTION
Removes the `/api` endpoint and routes.

Pages which need to access data from the API now call a `fetchData` function directly, rather than make a network request to `localhost`.

* Folder structure has changed slightly -- the `api` route no longer lives in `pages`, so now each page has its own top-level directory which contains an `index.tsx` file (for rendering the page) and an `api.js` file (for fetching the data). This means we don't need to duplicate folder structure across multiple levels when adding new pages.