### PR TITLE
fix: disables prefetching

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import Link from 'next/link';
+import { IsNextPage } from './Utils';
+
+const MonolithOrNextLink = ({ href, ...props}) => {
+  return IsNextPage(href) ? (
+    <Link href={href} prefetch={false}>
+      <a {...props} />
+    </Link>
+  ) : (
+      <a
+        href={`https://economy.id.com.au${href}`}
+        {...props}
+      />
+    );
+};
+
+export default MonolithOrNextLink;

--- a/src/components/MainNavigation.tsx
+++ b/src/components/MainNavigation.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import Link from 'next/link';
+import Link from '../components/Link';
 import styled from 'styled-components';
-import { pathParts, IsNextPage } from './Utils';
+import { pathParts } from './Utils';
 import _ from 'lodash';
-import Router, { useRouter } from 'next/router';
-// import { Location } from '@reach/router';
+import { useRouter } from 'next/router';
 import groupBy from 'lodash/groupBy';
 import OtherResources from './OtherRessources';
 const variables = require(`sass-extract-loader?{"plugins": ["sass-extract-js"]}!../styles/variables.scss`);
@@ -65,17 +64,6 @@ const buildMenu = (clientAlias, navigationNodes, ParentPageID = 0) => {
   ));
 };
 
-const MonolithOrNextLink = props => {
-  const { href, children, className } = props;
-  return IsNextPage(href) ? (
-    <Link href={`${href}`}>
-      <a {...{ children, className }} />
-    </Link>
-  ) : (
-    <a href={`https://economy.id.com.au${href}`} {...{ children, className }} />
-  );
-};
-
 const MainNavigation = ({ alias, navigationNodes }) => {
   return (
     <MainNav>
@@ -100,7 +88,7 @@ const MainNavigation = ({ alias, navigationNodes }) => {
 
 export default MainNavigation;
 
-const StyledLink = styled(MonolithOrNextLink)`
+const StyledLink = styled(Link)`
   text-decoration: none;
   color: ${variables.gray};
   display: block;

--- a/src/components/SiblingsMenu.tsx
+++ b/src/components/SiblingsMenu.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { pathParts, IsNextPage } from './Utils';
-import Link from 'next/link';
+import { pathParts } from './Utils';
 import styled from 'styled-components';
 import { useRouter } from 'next/router';
+import Link from '../components/Link';
+
 const variables = require(`sass-extract-loader?{"plugins": ["sass-extract-js"]}!../styles/variables.scss`);
 
 const SiblingsMenu = ({ navigationNodes, clientAlias }) => {
@@ -39,20 +40,6 @@ const SiblingsMenu = ({ navigationNodes, clientAlias }) => {
 
 export default SiblingsMenu;
 
-const MonolithOrNextLink = props => {
-  const { href, children, style, className } = props;
-  return IsNextPage(href) ? (
-    <Link href={`${href}`}>
-      <a {...{ children, style, className }} />
-    </Link>
-  ) : (
-    <a
-      href={`https://economy.id.com.au${href}`}
-      {...{ children, style, className }}
-    />
-  );
-};
-
 const SiblingsMenuContainer = styled.div`
   display: flex;
   flex-wrap: wrap;
@@ -62,7 +49,7 @@ const SiblingsMenuContainer = styled.div`
   border-bottom: 1px solid ${variables.grayLighter};
 `;
 
-const StyledLink = styled(MonolithOrNextLink)`
+const StyledLink = styled(Link)`
   text-decoration: none;
   color: ${variables.gray};
   padding: 0px 12px 0 12px;

--- a/src/components/SiteMap.tsx
+++ b/src/components/SiteMap.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
 import groupBy from 'lodash/groupBy';
-import { pathParts, IsNextPage } from './Utils';
 import _ from 'lodash';
-import Link from 'next/link';
+import Link from '../components/Link';
 import { FooterRow, SiteMapGrid } from './grid';
 const variables = require(`sass-extract-loader?{"plugins": ["sass-extract-js"]}!../styles/variables.scss`);
 
@@ -93,21 +92,7 @@ const DisabledLink = styled(PageItem)`
   cursor: default;
 `;
 
-const MonolithOrNextLink = props => {
-  const { href, children, style, className } = props;
-  return IsNextPage(href) ? (
-    <Link href={`${href}`}>
-      <a {...{ children, style, className }} />
-    </Link>
-  ) : (
-    <a
-      href={`https://economy.id.com.au${href}`}
-      {...{ children, style, className }}
-    />
-  );
-};
-
-const StyledLink = styled(MonolithOrNextLink)`
+const StyledLink = styled(Link)`
   font-size: 11px;
   line-height: 16px;
   text-decoration: none;


### PR DESCRIPTION
Next.js was prefetching Link URLs, which was leading to 404 errors as the paths were not statically compiled (as they use `getInitialProps` and are rendered per request).

To remedy this, the Link components now use `prefetch={false}`.

`MonolithOrNextLink` has been pulled out of each file which was using it and is now available as a top-level `Link` compontent.