### PR TITLE
Feat/split context

### DIFF
--- a/src/components/ClientHeader.tsx
+++ b/src/components/ClientHeader.tsx
@@ -1,8 +1,7 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import ClientProductsNav from './ClientProductsNav';
 import { HeaderRow } from './grid';
-import { ClientProductsContext, Context } from '../utils/context';
 
 const ClientLogo = styled.div`
   align-self: flex-end;
@@ -65,31 +64,26 @@ const HeaderWrapper = styled.div`
   grid-area: header;
 `;
 
-export const ClientHeader = ({ alias, prettyname, isLite, clientImage }) => {
-  const { clientProducts } = useContext(Context);
-  return (
-    <Decoration>
-      <HeaderRow>
-        <HeaderWrapper>
-          <Header>
-            <Stack>
-              <Title>
-                <ClientName>{prettyname} </ClientName>
-                <Separator />
-                <ProductName>economic profile{isLite && ' (lite)'}</ProductName>
-              </Title>
-              <ClientProductsContext.Provider value={{ clientProducts }}>
-                <ClientProductsNav alias={alias} />
-              </ClientProductsContext.Provider>
-            </Stack>
-            <ClientLogo>
-              <img src={clientImage} />
-            </ClientLogo>
-          </Header>
-        </HeaderWrapper>
-      </HeaderRow>
-    </Decoration>
-  );
-};
+export const ClientHeader = ({ alias, prettyname, isLite, clientImage }) => (
+  <Decoration>
+    <HeaderRow>
+      <HeaderWrapper>
+        <Header>
+          <Stack>
+            <Title>
+              <ClientName>{prettyname} </ClientName>
+              <Separator />
+              <ProductName>economic profile{isLite && ' (lite)'}</ProductName>
+            </Title>
+            <ClientProductsNav alias={alias} />
+          </Stack>
+          <ClientLogo>
+            <img src={clientImage} />
+          </ClientLogo>
+        </Header>
+      </HeaderWrapper>
+    </HeaderRow>
+  </Decoration>
+);
 
 export default ClientHeader;

--- a/src/components/ClientProductsNav.tsx
+++ b/src/components/ClientProductsNav.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import styled from 'styled-components';
-import { Context, ClientProductsContext } from '../utils/context';
+import { ClientContext } from '../utils/context';
 const variables = require(`sass-extract-loader?{"plugins": ["sass-extract-js"]}!../styles/variables.scss`);
 
 const ProductsNav = styled.nav`
@@ -73,7 +73,7 @@ const ProductItem = styled.a`
 `;
 
 const ClientProductsNav = ({ alias }) => {
-  const { clientProducts } = useContext(ClientProductsContext);
+  const { clientProducts } = useContext(ClientContext);
 
   return (
     <ProductsNav>

--- a/src/components/ControlPanel/ControlPanel.tsx
+++ b/src/components/ControlPanel/ControlPanel.tsx
@@ -26,21 +26,21 @@ const StyledControlPanel = styled.div`
 `;
 
 const ControlPanel: React.SFC<{}> = () => {
-  const { clientAlias } = React.useContext(ClientContext);
+  const { ClientAlias } = React.useContext(ClientContext);
   const { handle, toggles } = React.useContext(PageContext);
 
   const setQuery = (key, value) => {
     const query = qs.parse(location.search, { ignoreQueryPrefix: true });
     query[key] = value;
     Router.push({
-      pathname: `/${clientAlias}/${handle}`,
+      pathname: `/${ClientAlias}/${handle}`,
       query,
     });
   };
 
   const handleReset = () =>
     Router.push({
-      pathname: `/${clientAlias}/${handle}`,
+      pathname: `/${ClientAlias}/${handle}`,
       query: {},
     });
 

--- a/src/components/ControlPanel/ControlPanel.tsx
+++ b/src/components/ControlPanel/ControlPanel.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import Sticky from '@wicked_query/react-sticky';
 import Router from 'next/router';
 import qs from 'qs';
-import { Context } from '../../utils/context';
+import { PageContext, ClientContext } from '../../utils/context';
 
 const StyledControlPanel = styled.div`
   align-items: end;
@@ -26,7 +26,8 @@ const StyledControlPanel = styled.div`
 `;
 
 const ControlPanel: React.SFC<{}> = () => {
-  const { clientAlias, handle, toggles } = React.useContext(Context);
+  const { clientAlias } = React.useContext(ClientContext);
+  const { handle, toggles } = React.useContext(PageContext);
 
   const setQuery = (key, value) => {
     const query = qs.parse(location.search, { ignoreQueryPrefix: true });

--- a/src/components/DisabledPageWarning.tsx
+++ b/src/components/DisabledPageWarning.tsx
@@ -1,11 +1,16 @@
-const DisabledPageWarning = ({ client }) => {
+import { useContext } from 'react';
+import { ClientContext } from '../utils/context';
+
+const DisabledPageWarning = () => {
+  const { LongName } = useContext(ClientContext);
+
   return (
     <>
-      <h1>{client.LongName}</h1>
+      <h1>{LongName}</h1>
       <p>The page you requested is not available at this stage.</p>
       <p>
-        This dataset is available in the full version economy.id. Please contact
-        .id for more information on (+61) 3 94172205
+        This dataset is available in the full version economy.id. Please contact .id for more information on (+61) 3
+        94172205
       </p>
     </>
   );

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,13 +1,15 @@
 import React, { useContext } from 'react';
 import Link from 'next/link';
 import { IsNextPage } from '../utils/';
-import { Context } from '../utils/context';
+import { PageContext } from '../utils/context';
 
 const MonolithOrNextLink = ({ href, ...props }) => {
   const {
     filters: { WebID },
-  } = useContext(Context);
+  } = useContext(PageContext);
+
   const queryString = WebID === 10 ? '' : `?WebID=${WebID}`;
+
   return IsNextPage(href) ? (
     <Link href={`${href}${queryString}`} prefetch={false}>
       <a {...props} />

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,7 +1,8 @@
 import React, { useContext } from 'react';
 import Link from 'next/link';
-import { IsNextPage } from '../utils/';
+import { isNextPage } from '../layouts';
 import { PageContext } from '../utils/context';
+import { pathParts } from '../utils';
 
 const MonolithOrNextLink = ({ href, ...props }) => {
   const {
@@ -10,7 +11,9 @@ const MonolithOrNextLink = ({ href, ...props }) => {
 
   const queryString = WebID === 10 ? '' : `?WebID=${WebID}`;
 
-  return IsNextPage(href) ? (
+  const isNext = isNextPage(pathParts(href.split('?')[0]).pageAlias);
+
+  return isNext ? (
     <Link href={`${href}${queryString}`} prefetch={false}>
       <a {...props} />
     </Link>

--- a/src/components/MainNavigation.tsx
+++ b/src/components/MainNavigation.tsx
@@ -16,10 +16,14 @@ const buildMenuGroups = navNodes => groupBy(navNodes, 'GroupName');
 
 const validateGroupName = groupname => groupname !== '' && groupname !== 'Undefined';
 
-const buildMenu = (clientAlias, navigationNodes, ParentPageID = 0, WebID = 10) => {
+const buildMenu = (ClientAlias, navigationNodes, ParentPageID = 0, WebID = 10) => {
   const groupedNavigation = groupBy(navigationNodes, 'ParentPageID');
   const topNavNodes = groupedNavigation[ParentPageID];
   const menuGroups = buildMenuGroups(topNavNodes);
+
+  const location = useRouter().pathname;
+  const { pageAlias: currentPageAlias } = pathParts(location);
+  const isCurrent = buildIsCurrent(currentPageAlias);
 
   return _.map(menuGroups, (group, groupName) => (
     <React.Fragment key={groupName}>
@@ -27,10 +31,9 @@ const buildMenu = (clientAlias, navigationNodes, ParentPageID = 0, WebID = 10) =
       {group.map((topNode, i) => {
         const { Disabled, MenuTitle, Alias: pageAlias, PageID, ParentPageID } = topNode;
         const isParent = PageID in groupedNavigation && ParentPageID === 0;
-        const location = useRouter().pathname;
-        const { pageAlias: currentPageAlias } = pathParts(location);
-        const isCurrent = buildIsCurrent(currentPageAlias);
+
         const childIsCurrent = _.some(groupedNavigation[PageID], isCurrent);
+
         const isActive = childIsCurrent || pageAlias === currentPageAlias;
 
         return (
@@ -38,11 +41,11 @@ const buildMenu = (clientAlias, navigationNodes, ParentPageID = 0, WebID = 10) =
             {Disabled ? (
               <DisabledLink>{MenuTitle}</DisabledLink>
             ) : (
-              <StyledLink className={isActive && 'active'} href={`/${clientAlias}/${pageAlias}`}>
+              <StyledLink className={isActive && 'active'} href={`/${ClientAlias}/${pageAlias}`}>
                 {MenuTitle}
               </StyledLink>
             )}
-            {isParent && <SubMenu>{buildMenu(clientAlias, navigationNodes, PageID)}</SubMenu>}
+            {isParent && <SubMenu>{buildMenu(ClientAlias, navigationNodes, PageID)}</SubMenu>}
           </MenuItem>
         );
       })}

--- a/src/components/MainNavigation.tsx
+++ b/src/components/MainNavigation.tsx
@@ -6,7 +6,7 @@ import _ from 'lodash';
 import { useRouter } from 'next/router';
 import groupBy from 'lodash/groupBy';
 import OtherResources from './OtherRessources';
-import { Context } from '../utils/context';
+import { ClientContext } from '../utils/context';
 const variables = require(`sass-extract-loader?{"plugins": ["sass-extract-js"]}!../styles/variables.scss`);
 const MainNav = styled.div``;
 
@@ -51,12 +51,12 @@ const buildMenu = (clientAlias, navigationNodes, ParentPageID = 0, WebID = 10) =
 };
 
 const MainNavigation = ({ alias }) => {
-  const { navigation } = useContext(Context);
+  const { clientPages } = useContext(ClientContext);
 
   return (
     <MainNav>
       <Menu>
-        {buildMenu(alias, navigation)}
+        {buildMenu(alias, clientPages)}
         <GroupName>Other resources</GroupName>
         {OtherResources.map((link, i) => (
           <MenuItem key={i}>

--- a/src/components/PageHeader/index.tsx
+++ b/src/components/PageHeader/index.tsx
@@ -3,8 +3,8 @@ import React, { useContext } from 'react';
 import { Actions, Share, ExportPage } from '../Actions';
 import { TitleContainer, EntityContainer, MainTitle, SubTitle } from '../../styles/MainContentStyles';
 import getActiveToggle from '../../utils/getActiveToggle';
-import { Context } from '../../utils/context';
 import _ from 'lodash';
+import { ClientContext, PageContext } from '../../utils/context';
 
 const postData = async (url = '', data = {}) => {
   const response = await fetch(url, {
@@ -44,13 +44,12 @@ const handleExport = async currentAreaName => {
 };
 
 const PageHeader = () => {
-  const { clientData, toggles, pageData } = useContext(Context);
+  const { clientData } = useContext(ClientContext);
+  const { pageData, toggles } = useContext(PageContext);
 
   const { SubTitle: pageSubTitle } = pageData;
 
-  const currentAreaName = _.isEmpty(toggles)
-    ? clientData.LongName
-    : getActiveToggle(toggles, 'WebID', clientData.LongName);
+  const currentAreaName = getActiveToggle(toggles, 'WebID', clientData.LongName);
 
   return (
     <EntityContainer>

--- a/src/components/PageHeader/index.tsx
+++ b/src/components/PageHeader/index.tsx
@@ -44,12 +44,12 @@ const handleExport = async currentAreaName => {
 };
 
 const PageHeader = () => {
-  const { clientData } = useContext(ClientContext);
+  const { LongName } = useContext(ClientContext);
   const { pageData, toggles } = useContext(PageContext);
 
   const { SubTitle: pageSubTitle } = pageData;
 
-  const currentAreaName = getActiveToggle(toggles, 'WebID', clientData.LongName);
+  const currentAreaName = getActiveToggle(toggles, 'WebID', LongName);
 
   return (
     <EntityContainer>

--- a/src/components/RelatedPages/index.tsx
+++ b/src/components/RelatedPages/index.tsx
@@ -39,7 +39,7 @@ const StyledCTA = styled.div`
 `;
 
 const RelatedPagesCTA = () => {
-  const { clientAlias } = useContext(ClientContext);
+  const { ClientAlias } = useContext(ClientContext);
   const { pageData } = useContext(PageContext);
 
   const { RelatedPages } = pageData;
@@ -52,7 +52,7 @@ const RelatedPagesCTA = () => {
       <ul>
         {RelatedPages.map(({ Alias, MenuTitle }) => (
           <li key={Alias}>
-            <Link href={`${clientAlias}/${Alias}`}>
+            <Link href={`${ClientAlias}/${Alias}`}>
               <a>{MenuTitle}</a>
             </Link>
           </li>

--- a/src/components/RelatedPages/index.tsx
+++ b/src/components/RelatedPages/index.tsx
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
 
 import { useContext } from 'react';
-import { Context } from '../../utils/context';
 import Link from 'next/link';
+import { ClientContext, PageContext } from '../../utils/context';
 
 const variables = require(`sass-extract-loader?{"plugins": ["sass-extract-js"]}!../../styles/variables.scss`);
 
@@ -39,7 +39,8 @@ const StyledCTA = styled.div`
 `;
 
 const RelatedPagesCTA = () => {
-  const { clientAlias, pageData } = useContext(Context);
+  const { clientAlias } = useContext(ClientContext);
+  const { pageData } = useContext(PageContext);
 
   const { RelatedPages } = pageData;
 

--- a/src/components/SiblingsMenu.tsx
+++ b/src/components/SiblingsMenu.tsx
@@ -1,17 +1,18 @@
 import React, { useContext } from 'react';
 import styled from 'styled-components';
 import Link from '../components/Link';
-import { Context } from '../utils/context';
+import { ClientContext, PageContext } from '../utils/context';
 
 const variables = require(`sass-extract-loader?{"plugins": ["sass-extract-js"]}!../styles/variables.scss`);
 
 const SiblingsMenu = () => {
-  const { clientAlias, handle, navigation } = useContext(Context);
+  const { clientAlias, clientPages } = useContext(ClientContext);
+  const { handle } = useContext(PageContext);
 
-  const currentPageNode = navigation.find(node => node.Alias === handle);
+  const currentPageNode = clientPages.find(node => node.Alias === handle);
   const currentParentPageID = (currentPageNode && currentPageNode.ParentPageID) || 0;
 
-  const siblings = navigation
+  const siblings = clientPages
     .filter(node => node.ParentPageID === currentParentPageID)
     .map(({ Disabled, MenuTitle, Alias }) => (
       <React.Fragment key={Alias}>

--- a/src/components/SiblingsMenu.tsx
+++ b/src/components/SiblingsMenu.tsx
@@ -6,7 +6,7 @@ import { ClientContext, PageContext } from '../utils/context';
 const variables = require(`sass-extract-loader?{"plugins": ["sass-extract-js"]}!../styles/variables.scss`);
 
 const SiblingsMenu = () => {
-  const { clientAlias, clientPages } = useContext(ClientContext);
+  const { ClientAlias, clientPages } = useContext(ClientContext);
   const { handle } = useContext(PageContext);
 
   const currentPageNode = clientPages.find(node => node.Alias === handle);
@@ -19,7 +19,7 @@ const SiblingsMenu = () => {
         {Disabled ? (
           <DisabledLink>{MenuTitle}</DisabledLink>
         ) : (
-          <StyledLink href={`/${clientAlias}/${Alias}`} prefetch="false" className={handle === Alias && 'active'}>
+          <StyledLink href={`/${ClientAlias}/${Alias}`} prefetch="false" className={handle === Alias && 'active'}>
             {MenuTitle}
           </StyledLink>
         )}

--- a/src/components/SiteMap.tsx
+++ b/src/components/SiteMap.tsx
@@ -4,7 +4,8 @@ import groupBy from 'lodash/groupBy';
 import _ from 'lodash';
 import Link from '../components/Link';
 import { FooterRow, SiteMapGrid } from './grid';
-import { Context } from '../utils/context';
+import { ClientContext } from '../utils/context';
+
 const variables = require(`sass-extract-loader?{"plugins": ["sass-extract-js"]}!../styles/variables.scss`);
 
 const SiteMapHeader = styled.h1`
@@ -147,7 +148,7 @@ const buildSiteMap = (clientAlias, columns, navigation) => {
 };
 
 const SiteMap = ({ alias, prettyname }) => {
-  const { clientProducts, navigation, sitemapGroups } = useContext(Context);
+  const { clientProducts, clientPages, sitemapGroups } = useContext(ClientContext);
 
   const columns = _.values(groupBy(sitemapGroups, 'ColNumber'));
   return (
@@ -162,7 +163,7 @@ const SiteMap = ({ alias, prettyname }) => {
           <Subtitle>economic profile</Subtitle>
         </FooterContents>
       </FooterRow>
-      <SiteMapGrid>{buildSiteMap(alias, columns, navigation)}</SiteMapGrid>
+      <SiteMapGrid>{buildSiteMap(alias, columns, clientPages)}</SiteMapGrid>
       <FooterRow>
         <ProductItems>
           {clientProducts

--- a/src/components/SiteMap.tsx
+++ b/src/components/SiteMap.tsx
@@ -113,7 +113,7 @@ const Column = styled.div`
   grid-area: ${props => `col${props.col}`};
 `;
 
-const buildSiteMap = (clientAlias, columns, navigation) => {
+const buildSiteMap = (ClientAlias, columns, navigation) => {
   return columns.map((column, i) => {
     return (
       <Column key={i} col={i + 1}>
@@ -125,14 +125,14 @@ const buildSiteMap = (clientAlias, columns, navigation) => {
               <GroupName>{groups.GroupName}</GroupName>
               <PageList>
                 {pages.map((page, i) => {
-                  const { Alias: pageAlias, PageID, MenuTitle, Disabled } = page;
+                  const { Alias, PageID, MenuTitle, Disabled } = page;
                   return (
                     <React.Fragment key={PageID}>
                       {Disabled ? (
                         <DisabledLink>{MenuTitle}</DisabledLink>
                       ) : (
                         <li>
-                          <StyledLink href={`/${clientAlias}/${pageAlias}/`}>{MenuTitle}</StyledLink>
+                          <StyledLink href={`/${ClientAlias}/${Alias}/`}>{MenuTitle}</StyledLink>
                         </li>
                       )}
                     </React.Fragment>

--- a/src/components/table/EntityTable.tsx
+++ b/src/components/table/EntityTable.tsx
@@ -368,7 +368,7 @@ class EntityTable extends React.Component<any, any> {
     const SourceAndTopicNotesProps: ISourceAndTopicNotesProps = {
       source: data.source,
       anchorName: data.anchorName,
-      clientAlias: data.clientAlias,
+      ClientAlias: data.ClientAlias,
     };
     if (rows) {
       return (

--- a/src/components/table/Interfaces.table.ts
+++ b/src/components/table/Interfaces.table.ts
@@ -44,7 +44,7 @@ export interface ITableState {
 export interface ISourceAndTopicNotesProps {
   source: string;
   anchorName: any;
-  clientAlias: string;
+  ClientAlias: string;
 }
 
 export interface ISmallNoteProps {

--- a/src/components/table/SourceAndTopicNote.tsx
+++ b/src/components/table/SourceAndTopicNote.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 
-export const SourceAndTopicNotes = ({ source, anchorName, clientAlias }) =>
+export const SourceAndTopicNotes = ({ source, anchorName, ClientAlias }) =>
   !_.isEmpty(source) && (
     <div className="dataTableSource">
       <div>{source}</div>
@@ -10,7 +10,7 @@ export const SourceAndTopicNotes = ({ source, anchorName, clientAlias }) =>
           className="tableFooterNotes"
           target="_blank"
           title="Click for more information"
-          href={`https://economy.id.com.au/${clientAlias}/topic-notes#${anchorName}`}
+          href={`https://economy.id.com.au/${ClientAlias}/topic-notes#${anchorName}`}
         >
           Please refer to specific data notes for more information
         </a>

--- a/src/data/content.ts
+++ b/src/data/content.ts
@@ -17,9 +17,9 @@ export default {
     {
       Title: 'Headline',
       renderString: ({ data, tableData }): string =>
-        `<p>The Estimated Resident Population of ${data.currentAreaName} was ${formatNumber(
+        `The Estimated Resident Population of ${data.currentAreaName} was ${formatNumber(
           tableData[0].Number,
-        )} as of the 30th June ${tableData[0].Year}.</p>`,
+        )} as of the 30th June ${tableData[0].Year}.`,
     },
     {
       Title: 'Description',

--- a/src/layouts/gross-product/page/index.tsx
+++ b/src/layouts/gross-product/page/index.tsx
@@ -17,14 +17,14 @@ import getActiveToggle from '../../../utils/getActiveToggle';
 // #endregion
 
 const GrossProductPage = () => {
-  const { clientData, clientAlias } = useContext(ClientContext);
+  const { ClientAlias, LongName } = useContext(ClientContext);
   const { tableData, toggles } = useContext(PageContext);
 
-  // const currentAreaName = getActiveToggle(toggles, 'WebID', clientData.LongName);
+  // const currentAreaName = getActiveToggle(toggles, 'WebID', LongName);
 
   // const chartData = chartBuilder(tableData);
   // const chartLineData = chartLineBuilder(tableData);
-  // const tableParams = tableBuilder(clientAlias, tableData);
+  // const tableParams = tableBuilder(ClientAlias, tableData);
 
   // const latestPop = tableData[0].Number;
   // const latestYear = tableData[0].Year;
@@ -62,14 +62,14 @@ const Source = () => (
 // #endregion
 
 // #region tableBuilder
-const tableBuilder = (clientAlias, nodes) => {
+const tableBuilder = (ClientAlias, nodes) => {
   return {
     cssClass: '',
     allowExport: false,
     allowSort: true,
     allowSortReset: true,
     groupOn: '',
-    clientAlias,
+    ClientAlias,
     source: <Source />,
     anchorName: 'service-age-groups',
     headRows: [

--- a/src/layouts/gross-product/page/index.tsx
+++ b/src/layouts/gross-product/page/index.tsx
@@ -10,15 +10,15 @@ import {
 } from '../../../styles/MainContentStyles';
 import EntityTable from '../../../components/table/EntityTable';
 import EntityChart from '../../../components/chart/EntityChart';
-import { Context } from '../../../utils/context';
+import { ClientContext, PageContext } from '../../../utils/context';
 import ControlPanel from '../../../components/ControlPanel/ControlPanel';
 import { useContext } from 'react';
 import getActiveToggle from '../../../utils/getActiveToggle';
 // #endregion
 
-// #region population page
-const PopulationPage = () => {
-  const { clientData, clientAlias, tableData, toggles } = useContext(Context);
+const GrossProductPage = () => {
+  const { clientData, clientAlias } = useContext(ClientContext);
+  const { tableData, toggles } = useContext(PageContext);
 
   // const currentAreaName = getActiveToggle(toggles, 'WebID', clientData.LongName);
 
@@ -46,9 +46,7 @@ const PopulationPage = () => {
   );
 };
 
-// #endregion
-
-export default PopulationPage;
+export default GrossProductPage;
 
 // #region Source
 const Source = () => (

--- a/src/layouts/index.ts
+++ b/src/layouts/index.ts
@@ -1,0 +1,27 @@
+import EconomicImpactAssesment from './economic-impact-assesment/page';
+import GrossProduct from './gross-product/page';
+import Indicator from './indicator/page';
+import Population from './population/page';
+import ValueOfBuildingApprovals from './value-of-building-approvals/page';
+import WorkersFieldOfQualification from './workers-field-of-qualification/page';
+
+const productionPages = {
+  population: Population,
+};
+
+const devPages = {
+  'gross-product': GrossProduct,
+  indicator: Indicator,
+  population: Population,
+  'value-of-building-approvals': ValueOfBuildingApprovals,
+  'workers-field-of-qualification': WorkersFieldOfQualification,
+  'economic-impact-assesment': EconomicImpactAssesment,
+};
+
+export default () => {
+  if (process.env.NODE_ENV === 'production') {
+    return productionPages;
+  }
+
+  return devPages;
+};

--- a/src/layouts/index.ts
+++ b/src/layouts/index.ts
@@ -5,11 +5,18 @@ import Population from './population/page';
 import ValueOfBuildingApprovals from './value-of-building-approvals/page';
 import WorkersFieldOfQualification from './workers-field-of-qualification/page';
 
-const productionPages = {
-  population: Population,
-};
+const productionPages = ['population'];
 
-const devPages = {
+const devPages = [
+  'gross-product',
+  'indicator',
+  'population',
+  'value-of-building-approvals',
+  'workers-field-of-qualification',
+  'economic-impact-assesment',
+];
+
+export const PageMappings = {
   'gross-product': GrossProduct,
   indicator: Indicator,
   population: Population,
@@ -18,10 +25,24 @@ const devPages = {
   'economic-impact-assesment': EconomicImpactAssesment,
 };
 
-export default () => {
-  if (process.env.NODE_ENV === 'production') {
-    return productionPages;
+const fetchPageData = async handle => {
+  const pageData = await import(`./${handle}`);
+
+  return pageData;
+};
+
+export const isNextPage = handle => {
+  const availablePages = process.env.NODE_ENV === 'production' ? productionPages : devPages;
+
+  return availablePages.indexOf(handle) >= 0;
+};
+
+export default async handle => {
+  if (!isNextPage(handle)) {
+    return null;
   }
 
-  return devPages;
+  const pageData = await fetchPageData(handle);
+
+  return pageData;
 };

--- a/src/layouts/index.ts
+++ b/src/layouts/index.ts
@@ -5,6 +5,15 @@ import Population from './population/page';
 import ValueOfBuildingApprovals from './value-of-building-approvals/page';
 import WorkersFieldOfQualification from './workers-field-of-qualification/page';
 
+export const PageMappings = {
+  'gross-product': GrossProduct,
+  indicator: Indicator,
+  population: Population,
+  'value-of-building-approvals': ValueOfBuildingApprovals,
+  'workers-field-of-qualification': WorkersFieldOfQualification,
+  'economic-impact-assesment': EconomicImpactAssesment,
+};
+
 const productionPages = ['population'];
 
 const devPages = [
@@ -15,15 +24,6 @@ const devPages = [
   'workers-field-of-qualification',
   'economic-impact-assesment',
 ];
-
-export const PageMappings = {
-  'gross-product': GrossProduct,
-  indicator: Indicator,
-  population: Population,
-  'value-of-building-approvals': ValueOfBuildingApprovals,
-  'workers-field-of-qualification': WorkersFieldOfQualification,
-  'economic-impact-assesment': EconomicImpactAssesment,
-};
 
 const fetchPageData = async handle => {
   const pageData = await import(`./${handle}`);

--- a/src/layouts/main.tsx
+++ b/src/layouts/main.tsx
@@ -16,29 +16,28 @@ import { ClientContext, PageContext } from '../utils/context';
 const IsLite = nodes => some(nodes, 'Disabled');
 
 const Layout = ({ children }) => {
-  const { clientData, clientPages } = useContext(ClientContext);
+  const { ClientAlias, clientID, clientPages, LongName } = useContext(ClientContext);
   const { handle } = useContext(PageContext);
 
-  const { Alias: alias, clientID, LongName: prettyname, Name: name } = clientData;
-  const logo = require(`../images/logos/${alias}.png`);
+  const logo = require(`../images/logos/${ClientAlias}.png`);
   const isDisabled = IsDisabled(clientPages, handle);
   const isSecure = IsSecure(clientPages, handle);
 
   return (
     <>
-      <SearchApp alias={alias} clientID={clientID} prettyname={prettyname} clientImage={logo} />
-      <ClientHeader alias={alias} prettyname={prettyname} clientImage={logo} isLite={IsLite(clientPages)} />
+      <SearchApp alias={ClientAlias} clientID={clientID} prettyname={LongName} clientImage={logo} />
+      <ClientHeader alias={ClientAlias} prettyname={LongName} clientImage={logo} isLite={IsLite(clientPages)} />
       <ContentRow>
         <SidebarNav>
-          <MainNavigation alias={alias} />
+          <MainNavigation alias={ClientAlias} />
         </SidebarNav>
         <SiteContent id={'main-content'}>
           <SiblingsMenu />
           {isSecure ? <Secured /> : <Unsecured />}
-          {isDisabled ? <DisabledPageWarning client={clientData} /> : children}
+          {isDisabled ? <DisabledPageWarning /> : children}
         </SiteContent>
       </ContentRow>
-      <SiteMap alias={alias} prettyname={prettyname} />
+      <SiteMap alias={ClientAlias} prettyname={LongName} />
       <SharedFooter />
     </>
   );

--- a/src/layouts/main.tsx
+++ b/src/layouts/main.tsx
@@ -10,22 +10,24 @@ import some from 'lodash/some';
 import SiblingsMenu from '../components/SiblingsMenu';
 import { IsDisabled, IsSecure } from '../utils/';
 import DisabledPageWarning from '../components/DisabledPageWarning';
-import { Context } from '../utils/context';
 import { SidebarNav, SiteContent } from '../styles/MainContentStyles';
 import { Secured, Unsecured } from '../styles/ui';
+import { ClientContext, PageContext } from '../utils/context';
 const IsLite = nodes => some(nodes, 'Disabled');
 
 const Layout = ({ children }) => {
-  const { clientData, handle, navigation } = useContext(Context);
+  const { clientData, clientPages } = useContext(ClientContext);
+  const { handle } = useContext(PageContext);
+
   const { Alias: alias, clientID, LongName: prettyname, Name: name } = clientData;
   const logo = require(`../images/logos/${alias}.png`);
-  const isDisabled = IsDisabled(navigation, handle);
-  const isSecure = IsSecure(navigation, handle);
+  const isDisabled = IsDisabled(clientPages, handle);
+  const isSecure = IsSecure(clientPages, handle);
 
   return (
     <>
       <SearchApp alias={alias} clientID={clientID} prettyname={prettyname} clientImage={logo} />
-      <ClientHeader alias={alias} prettyname={prettyname} clientImage={logo} isLite={IsLite(navigation)} />
+      <ClientHeader alias={alias} prettyname={prettyname} clientImage={logo} isLite={IsLite(clientPages)} />
       <ContentRow>
         <SidebarNav>
           <MainNavigation alias={alias} />

--- a/src/layouts/parentLandingPages.tsx
+++ b/src/layouts/parentLandingPages.tsx
@@ -23,30 +23,29 @@ const SiteContent = styled.div`
 `;
 
 const ParentLandingPageLayout = ({ children = null }) => {
-  const { clientData, clientPages } = useContext(ClientContext);
+  const { ClientAlias, clientID, clientPages, LongName } = useContext(ClientContext);
   const { handle } = useContext(PageContext);
 
-  const { Alias: alias, clientID, LongName: prettyname, Name: name } = clientData;
-  const logo = require(`../images/logos/${alias}.png`);
+  const logo = require(`../images/logos/${ClientAlias}.png`);
   const isDisabled = IsDisabled(clientPages, handle);
   const isSecure = IsSecure(clientPages, handle);
 
   return (
     <>
-      <SearchApp alias={alias} clientID={clientID} prettyname={prettyname} clientImage={logo} />
-      <ClientHeader alias={alias} prettyname={prettyname} clientImage={logo} isLite={IsLite(clientPages)} />
+      <SearchApp alias={ClientAlias} clientID={clientID} prettyname={LongName} clientImage={logo} />
+      <ClientHeader alias={ClientAlias} prettyname={LongName} clientImage={logo} isLite={IsLite(clientPages)} />
       <ContentRow>
         <SidebarNav>
-          <MainNavigation alias={alias} />
+          <MainNavigation alias={ClientAlias} />
         </SidebarNav>
         <SiteContent id={'main-content'}>
           Select a topic
           <SiblingsMenu />
           {isSecure ? <Secured /> : <Unsecured />}
-          {isDisabled ? <DisabledPageWarning client={clientData} /> : children}
+          {isDisabled ? <DisabledPageWarning /> : children}
         </SiteContent>
       </ContentRow>
-      <SiteMap alias={alias} prettyname={prettyname} />
+      <SiteMap alias={ClientAlias} prettyname={LongName} />
       <SharedFooter />
     </>
   );

--- a/src/layouts/parentLandingPages.tsx
+++ b/src/layouts/parentLandingPages.tsx
@@ -10,8 +10,8 @@ import some from 'lodash/some';
 import SiblingsMenu from '../components/SiblingsMenu';
 import { IsDisabled, IsSecure } from '../utils/';
 import DisabledPageWarning from '../components/DisabledPageWarning';
-import { Context } from '../utils/context';
 import { Secured, Unsecured } from '../styles/ui';
+import { ClientContext, PageContext } from '../utils/context';
 const IsLite = nodes => some(nodes, 'Disabled');
 
 const SidebarNav = styled.div`
@@ -23,17 +23,18 @@ const SiteContent = styled.div`
 `;
 
 const ParentLandingPageLayout = ({ children = null }) => {
-  const { clientData, handle, navigation } = useContext(Context);
+  const { clientData, clientPages } = useContext(ClientContext);
+  const { handle } = useContext(PageContext);
 
   const { Alias: alias, clientID, LongName: prettyname, Name: name } = clientData;
   const logo = require(`../images/logos/${alias}.png`);
-  const isDisabled = IsDisabled(navigation, handle);
-  const isSecure = IsSecure(navigation, handle);
+  const isDisabled = IsDisabled(clientPages, handle);
+  const isSecure = IsSecure(clientPages, handle);
 
   return (
     <>
       <SearchApp alias={alias} clientID={clientID} prettyname={prettyname} clientImage={logo} />
-      <ClientHeader alias={alias} prettyname={prettyname} clientImage={logo} isLite={IsLite(navigation)} />
+      <ClientHeader alias={alias} prettyname={prettyname} clientImage={logo} isLite={IsLite(clientPages)} />
       <ContentRow>
         <SidebarNav>
           <MainNavigation alias={alias} />

--- a/src/layouts/population/page/index.tsx
+++ b/src/layouts/population/page/index.tsx
@@ -1,58 +1,26 @@
 // #region imports
 import _ from 'lodash';
 import { formatShortDecimal, formatNumber, formatChangeNumber, formatChangePercent } from '../../../utils';
-import {
-  Headline,
-  ItemWrapper,
-  CrossLink,
-  PageIntroFullWidth,
-  ForecastProductIcon,
-} from '../../../styles/MainContentStyles';
+import { ItemWrapper, CrossLink, ForecastProductIcon } from '../../../styles/MainContentStyles';
 import EntityTable from '../../../components/table/EntityTable';
 import EntityChart from '../../../components/chart/EntityChart';
-import ControlPanel from '../../../components/ControlPanel/ControlPanel';
 import { useContext } from 'react';
-import getActiveToggle from '../../../utils/getActiveToggle';
 import { PageContext, ClientContext } from '../../../utils/context';
 // #endregion
 
 // #region population page
 const PopulationPage = () => {
-  const { clientData, clientAlias, clientProducts } = useContext(ClientContext);
-  const { tableData, toggles } = useContext(PageContext);
-
-  const currentAreaName = getActiveToggle(toggles, 'WebID', clientData.LongName);
+  const { ClientAlias, clientProducts } = useContext(ClientContext);
+  const { tableData } = useContext(PageContext);
 
   const hasForecast = clientProducts => _.some(clientProducts, product => product.AppID === 3);
 
-  const FormattedNumber = ({ number }) => <>{formatNumber(number)}</>;
-
   const chartData = chartBuilder(tableData);
   const chartLineData = chartLineBuilder(tableData);
-  const tableParams = tableBuilder(clientAlias, tableData);
-  const latestPop = tableData[0].Number;
-  const latestYear = tableData[0].Year;
+  const tableParams = tableBuilder(ClientAlias, tableData);
 
   return (
     <>
-      <Headline>
-        The Estimated Resident Population of the {currentAreaName} was <FormattedNumber number={latestPop} /> as of the
-        30th June {latestYear}.
-      </Headline>
-      <PageIntroFullWidth>
-        <p>
-          The Estimated Resident Population (ERP) is the official population of the area. It is updated annually by the
-          Australian Bureau of Statistics, and reassessed every Census. The chart and table show last 10 years ERP for{' '}
-          {currentAreaName}, the state and Australia, with percentage comparisons. A growing population can indicate a
-          growing economy, but this is not necessarily the case and depends on the residential role and function of the
-          area.
-        </p>
-      </PageIntroFullWidth>
-
-      <ItemWrapper>
-        <ControlPanel />
-      </ItemWrapper>
-
       <ItemWrapper>
         <EntityChart data={chartData} />
       </ItemWrapper>
@@ -69,7 +37,7 @@ const PopulationPage = () => {
         <CrossLink>
           <ForecastProductIcon />
           <a
-            href={`http://forecast.id.com.au/${clientAlias}/population-summary?WebId=10`}
+            href={`http://forecast.id.com.au/${ClientAlias}/population-summary?WebId=10`}
             target="_blank"
             title="link to forecast"
           >
@@ -107,7 +75,7 @@ const tableBuilder = (alias, nodes) => {
     allowSort: true,
     allowSortReset: true,
     groupOn: '',
-    clientAlias: alias,
+    ClientAlias: alias,
     source: <Source />,
     anchorName: 'service-age-groups',
     headRows: [

--- a/src/layouts/population/page/index.tsx
+++ b/src/layouts/population/page/index.tsx
@@ -10,15 +10,16 @@ import {
 } from '../../../styles/MainContentStyles';
 import EntityTable from '../../../components/table/EntityTable';
 import EntityChart from '../../../components/chart/EntityChart';
-import { Context } from '../../../utils/context';
 import ControlPanel from '../../../components/ControlPanel/ControlPanel';
 import { useContext } from 'react';
 import getActiveToggle from '../../../utils/getActiveToggle';
+import { PageContext, ClientContext } from '../../../utils/context';
 // #endregion
 
 // #region population page
 const PopulationPage = () => {
-  const { clientData, clientAlias, tableData, clientProducts, toggles } = useContext(Context);
+  const { clientData, clientAlias, clientProducts } = useContext(ClientContext);
+  const { tableData, toggles } = useContext(PageContext);
 
   const currentAreaName = getActiveToggle(toggles, 'WebID', clientData.LongName);
 

--- a/src/layouts/value-of-building-approvals/page/index.tsx
+++ b/src/layouts/value-of-building-approvals/page/index.tsx
@@ -10,12 +10,12 @@ import { ClientContext, PageContext } from '../../../utils/context';
 
 // #region population page
 const ValueOfBuildingApprovalsPage = () => {
-  const { clientAlias } = useContext(ClientContext);
+  const { ClientAlias } = useContext(ClientContext);
   const { tableData } = useContext(PageContext);
 
   const pageName = 'Value of total building approvals';
   const chartData = chartBuilder(tableData);
-  const tableParams = tableBuilder(clientAlias, tableData);
+  const tableParams = tableBuilder(ClientAlias, tableData);
 
   return (
     <>
@@ -54,7 +54,7 @@ const tableBuilder = (alias, nodes) => {
     allowSort: true,
     allowSortReset: true,
     groupOn: '',
-    clientAlias: alias,
+    ClientAlias: alias,
     source: <Source />,
     anchorName: 'service-age-groups',
     headRows: [

--- a/src/layouts/value-of-building-approvals/page/index.tsx
+++ b/src/layouts/value-of-building-approvals/page/index.tsx
@@ -4,15 +4,15 @@ import { formatNumber, formatPercent } from '../../../utils/';
 import { ItemWrapper } from '../../../styles/MainContentStyles';
 import EntityTable from '../../../components/table/EntityTable';
 import EntityChart from '../../../components/chart/EntityChart';
-import { Context } from '../../../utils/context';
 import { useContext } from 'react';
+import { ClientContext, PageContext } from '../../../utils/context';
 // #endregion
 
 // #region population page
 const ValueOfBuildingApprovalsPage = () => {
-  const { clientData, tableData } = useContext(Context);
+  const { clientAlias } = useContext(ClientContext);
+  const { tableData } = useContext(PageContext);
 
-  const { clientAlias } = clientData;
   const pageName = 'Value of total building approvals';
   const chartData = chartBuilder(tableData);
   const tableParams = tableBuilder(clientAlias, tableData);

--- a/src/layouts/workers-field-of-qualification/page/index.tsx
+++ b/src/layouts/workers-field-of-qualification/page/index.tsx
@@ -192,10 +192,10 @@ const EmergingGroups = () => {
 
 // #region page
 const LocalWorkerFieldsOfQualificationPage = () => {
-  const { clientData, clientAlias, clientProducts } = useContext(ClientContext);
+  const { ClientAlias, clientProducts, LongName } = useContext(ClientContext);
   const { tableData, toggles } = useContext(PageContext);
 
-  const currentAreaName = getActiveToggle(toggles, 'WebID', clientData.LongName);
+  const currentAreaName = getActiveToggle(toggles, 'WebID', LongName);
   const currentIndustryName = getActiveToggle(toggles, 'Indkey');
   const currentBenchmarkName = getActiveToggle(toggles, 'IGBMID');
   const currentGenderName = getActiveToggle(toggles, 'Sex');
@@ -251,9 +251,9 @@ const LocalWorkerFieldsOfQualificationPage = () => {
           </p>
           <p>
             Field of Qualification information should be looked at in conjunction with{' '}
-            <a href={`${clientAlias}/workers-level-of-qualifications?`}>Level of qualification </a>
-            and <a href={`${clientAlias}/workers-occupations?`}>Occupation</a> data for a clearer picture of the skills
-            available for the local workers in {clientData.LongName}.
+            <a href={`${ClientAlias}/workers-level-of-qualifications?`}>Level of qualification </a>
+            and <a href={`${ClientAlias}/workers-occupations?`}>Occupation</a> data for a clearer picture of the skills
+            available for the local workers in {LongName}.
           </p>
         </div>
         <SourceBubble>
@@ -269,10 +269,10 @@ const LocalWorkerFieldsOfQualificationPage = () => {
         <strong>Please note</strong> – The 2016 Census used a new methodology to “impute” a work location to people who
         didn’t state their workplace address. As a result, 2016 and 2011 place of work data are not normally comparable.
         To allow comparison between 2011 and 2016, .id has sourced a 2011 dataset from the ABS which was experimentally
-        imputed using the same methodology. To provide this detail, {clientData.LongName} in 2011 had to be constructed
-        from a best fit of Work Destination Zones (DZNs). While it may not be an exact match to the LGA or region
-        boundary, it is considered close enough to allow some comparison. Users should treat this time series data with
-        caution, however, and not compare directly with 2011 data from any other source.
+        imputed using the same methodology. To provide this detail, {LongName} in 2011 had to be constructed from a best
+        fit of Work Destination Zones (DZNs). While it may not be an exact match to the LGA or region boundary, it is
+        considered close enough to allow some comparison. Users should treat this time series data with caution,
+        however, and not compare directly with 2011 data from any other source.
       </Note>
 
       <InfoBox>
@@ -289,7 +289,7 @@ const LocalWorkerFieldsOfQualificationPage = () => {
         <CrossLink>
           <ProfileProductIcon />
           <a
-            href={`http://profile.id.com.au/${clientAlias}/qualifications?WebId=10`}
+            href={`http://profile.id.com.au/${ClientAlias}/qualifications?WebId=10`}
             target="_blank"
             title="link to forecast"
           >
@@ -391,7 +391,7 @@ const tableBuilder = ({
     allowSort: true,
     allowSortReset: true,
     groupOn: '',
-    clientAlias: 'Monash',
+    ClientAlias: 'Monash',
     source: <Source />,
     rawDataSource:
       'Source: Australian Bureau of Statistics, Regional Population Growth, Australia (3218.0). Compiled and presented in economy.id by.id, the population experts.',

--- a/src/layouts/workers-field-of-qualification/page/index.tsx
+++ b/src/layouts/workers-field-of-qualification/page/index.tsx
@@ -16,9 +16,9 @@ import {
   ProfileProductIcon,
 } from '../../../styles/MainContentStyles';
 import InfoBox from '../../../components/InfoBox';
-import { Context } from '../../../utils/context';
 import getActiveToggle from '../../../utils/getActiveToggle';
 import RelatedPagesCTA from '../../../components/RelatedPages';
+import { ClientContext, PageContext } from '../../../utils/context';
 
 // #endregion
 
@@ -37,18 +37,8 @@ const Top = n => quals =>
 const TopThree = Top(3);
 const TopFour = Top(4);
 
-const HighestQualification = () => {
-  const { tableData } = useContext(Context);
-
-  const topquals = TopLevelQualifications(tableData);
-  const highestQuals = HighestQualifications(topquals, 'NoYear1');
-  const biggest: any = highestQuals.pop();
-
-  return (biggest || {}).LabelName;
-};
-
 const TopThreeFields = ({ industryName }) => {
-  const { tableData } = useContext(Context);
+  const { tableData } = useContext(PageContext);
 
   const topquals = TopLevelQualifications(tableData);
   const highestQuals = HighestQualifications(topquals, 'NoYear1');
@@ -78,7 +68,7 @@ const ComparisonBenchmark = ({ areaName, benchmarkName }) => {
   const {
     filters: { IGBMID },
     tableData,
-  } = useContext(Context);
+  } = useContext(PageContext);
 
   let currentBenchmarkName: any = benchmarkName;
 
@@ -110,7 +100,7 @@ const ComparisonBenchmark = ({ areaName, benchmarkName }) => {
 const MajorDifferencesHeading = ({ areaName, benchmarkName, industryName }) => {
   const {
     filters: { IGBMID, Indkey },
-  } = useContext(Context);
+  } = useContext(PageContext);
 
   let industryText = industryName;
   if (Indkey == 23000) {
@@ -137,7 +127,7 @@ const MajorDifferencesHeading = ({ areaName, benchmarkName, industryName }) => {
 };
 
 const MajorDifferences = ({ areaName, benchmarkName, industryName }) => {
-  const { tableData } = useContext(Context);
+  const { tableData } = useContext(PageContext);
 
   const topquals = TopLevelQualifications(tableData);
   const qualsWithData = _.filter(_.filter(topquals, 'PerYear1'), 'BMYear1');
@@ -165,7 +155,7 @@ const MajorDifferences = ({ areaName, benchmarkName, industryName }) => {
 const EmergingGroupsHeading = ({ areaName, industryName }) => {
   const {
     filters: { Indkey },
-  } = useContext(Context);
+  } = useContext(PageContext);
 
   let industryText = industryName;
   if (Indkey == 23000) {
@@ -182,7 +172,7 @@ const EmergingGroupsHeading = ({ areaName, industryName }) => {
 };
 
 const EmergingGroups = () => {
-  const { tableData } = useContext(Context);
+  const { tableData } = useContext(PageContext);
 
   const topquals = TopLevelQualifications(tableData);
   const highestQuals = HighestQualifications(topquals, 'Change12');
@@ -202,7 +192,8 @@ const EmergingGroups = () => {
 
 // #region page
 const LocalWorkerFieldsOfQualificationPage = () => {
-  const { clientAlias, clientData, tableData, clientProducts, toggles } = useContext(Context);
+  const { clientData, clientAlias, clientProducts } = useContext(ClientContext);
+  const { tableData, toggles } = useContext(PageContext);
 
   const currentAreaName = getActiveToggle(toggles, 'WebID', clientData.LongName);
   const currentIndustryName = getActiveToggle(toggles, 'Indkey');

--- a/src/pages/[clientAlias]/[handle]/index.tsx
+++ b/src/pages/[clientAlias]/[handle]/index.tsx
@@ -5,7 +5,7 @@ import { useContext } from 'react';
 import fetchClientData from '../../../utils/fetchClientData';
 // #endregion
 
-import PageMappings from '../../../layouts';
+import fetchLayout, { PageMappings } from '../../../layouts';
 import MainLayout from '../../../layouts/main';
 import ParentLandingPageLayout from '../../../layouts/parentLandingPages';
 
@@ -27,7 +27,7 @@ const PageTemplate = () => {
 
   const { ParentPageID } = pageData;
 
-  const MainContent = PageMappings()[handle];
+  const MainContent = PageMappings[handle];
 
   if (!ParentPageID) {
     return (
@@ -92,7 +92,9 @@ PageComponent.getInitialProps = async function({ query, req: { containers } }) {
     currentIndustryName: getActiveToggle(toggles, 'Indkey'),
   };
 
-  const { fetchData } = await import(`../../../layouts/${handle}`);
+  const layoutData = await fetchLayout(handle);
+
+  const { fetchData } = layoutData;
 
   const tableData = await fetchData({ filters });
 

--- a/src/pages/[clientAlias]/[handle]/index.tsx
+++ b/src/pages/[clientAlias]/[handle]/index.tsx
@@ -25,6 +25,10 @@ import { PageContext, ClientContext } from '../../../utils/context';
 const PageTemplate = () => {
   const { pageData, handle } = useContext(PageContext);
 
+  if (!pageData) {
+    return <MainLayout>404</MainLayout>;
+  }
+
   const { ParentPageID } = pageData;
 
   const MainContent = PageMappings[handle];
@@ -93,6 +97,11 @@ PageComponent.getInitialProps = async function({ query, req: { containers } }) {
   };
 
   const layoutData = await fetchLayout(handle);
+
+  if (!layoutData) {
+    // 404
+    return { client, page: { pageData: null, filters, handle } };
+  }
 
   const { fetchData } = layoutData;
 

--- a/src/pages/[clientAlias]/index.tsx
+++ b/src/pages/[clientAlias]/index.tsx
@@ -5,7 +5,7 @@ const ClientLandingPage = ({ title }) => {
 };
 
 ClientLandingPage.getInitialProps = async context => {
-  const title = `Landing page for ${context.query.clientAlias}`;
+  const title = `Landing page for ${context.query.ClientAlias}`;
   return { title };
 };
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { CenteredContainer } from '../components/grid';
 import ClientProductsNav from '../components/ClientProductsNav';
 import SharedFooter from '../components/SharedFooter';
-import { Context, ClientProductsContext } from '../utils/context';
+import { ClientContext } from '../utils/context';
 
 const LogoGrid = styled.div`
   display: grid;
@@ -117,7 +117,7 @@ const HomePage = ({ clients }) => {
   ));
 
   return (
-    <ClientProductsContext.Provider value={{ clientProducts: products }}>
+    <ClientContext.Provider value={{ clientProducts: products }}>
       <CenteredContainer>
         <IDidentity />
       </CenteredContainer>
@@ -150,7 +150,7 @@ const HomePage = ({ clients }) => {
         <LogoGrid>{clientList}</LogoGrid>
       </CenteredContainer>
       <SharedFooter />
-    </ClientProductsContext.Provider>
+    </ClientContext.Provider>
   );
 };
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -109,8 +109,8 @@ const products = [
 const HomePage = ({ clients }) => {
   const clientList = clients.map(client => (
     <Tile key={client.ClientID}>
-      <Link href={`/${client.Alias}`} prefetch={false}>
-        <ClientLogo src={require(`../images/logos/${client.Alias}.png`)} />
+      <Link href={`/${client.ClientAlias}`} prefetch={false}>
+        <ClientLogo src={require(`../images/logos/${client.ClientAlias}.png`)} />
       </Link>
       <CouncilName>{client.Name}</CouncilName>
     </Tile>

--- a/src/utils/context/index.ts
+++ b/src/utils/context/index.ts
@@ -1,12 +1,14 @@
 import React from 'react';
 
 type ClientProps = {
-  clientAlias?: string;
+  clientID?: number;
+  ClientAlias?: string;
   clientAreas?: Array<any>;
-  clientData?: any;
   clientPages?: Array<any>;
   clientProducts?: Array<any>;
   sitemapGroups?: Array<any>;
+  LongName?: string;
+  Name?: string;
 };
 
 type PageProps = {

--- a/src/utils/context/index.ts
+++ b/src/utils/context/index.ts
@@ -1,21 +1,24 @@
 import React from 'react';
 
-export const Context = React.createContext({
-  clientData: null,
-  clientAlias: null,
-  handle: null,
-  tableData: null,
-  navigation: null,
-  clientProducts: null,
-  sitemapGroups: null,
-  filters: null,
-  clientAreas: null,
-  toggles: null,
-  pageData: null,
-  entities: null,
-  templateArgs: null,
-});
+type ClientProps = {
+  clientAlias?: string;
+  clientAreas?: Array<any>;
+  clientData?: any;
+  clientPages?: Array<any>;
+  clientProducts?: Array<any>;
+  sitemapGroups?: Array<any>;
+};
 
-export const ClientProductsContext = React.createContext({
-  clientProducts: null,
-});
+type PageProps = {
+  entities?: Array<any>;
+  handle?: string;
+  filters?: any;
+  tableData?: Array<any>;
+  toggles?: Array<any>;
+  pageData?: any;
+};
+
+const ClientContext = React.createContext<Partial<ClientProps>>({});
+const PageContext = React.createContext<Partial<PageProps>>({});
+
+export { ClientContext, PageContext };

--- a/src/utils/fetchAllClients/index.ts
+++ b/src/utils/fetchAllClients/index.ts
@@ -33,7 +33,7 @@ WITH RDAS AS (
     ON client.ClientID = RDAS.ClientID
   WHERE clientMeta.IsDisabled = 0
     AND clientMeta.ApplicationID = 4
-  ${ignoreClients.map(clientAlias => `  AND NOT client.Alias = '${clientAlias}'`).join('\n')}
+  ${ignoreClients.map(ClientAlias => `  AND NOT client.Alias = '${ClientAlias}'`).join('\n')}
 `;
 /* #endregion */
 

--- a/src/utils/fetchClientData/index.ts
+++ b/src/utils/fetchClientData/index.ts
@@ -1,11 +1,13 @@
-const fetchClientData = async ({ clientAlias, containers }) => {
+import fetchSitemap from '../fetchSitemap';
+
+const queryClientDB = async ({ ClientAlias, containers }) => {
   const { ClientContainer, AllPages } = containers;
 
   const { resources: clientData } = await ClientContainer.items
-    .query(`SELECT * FROM c WHERE c.Alias = "${clientAlias}"`)
+    .query(`SELECT * FROM c WHERE c.Alias = "${ClientAlias}"`)
     .fetchAll();
 
-  const { Alias, id, ShortName, LongName, Name, Pages, Applications, Areas } = clientData[0];
+  const { Alias, Applications, Areas, id, ShortName, LongName, Name, Pages } = clientData[0];
 
   const filteredAreas = Areas.filter(({ AppID }) => AppID === 4).map(area => ({ ...area, ID: area.WebID }));
   const filteredPages = Pages.filter(({ AppID }) => AppID === 4);
@@ -18,7 +20,7 @@ const fetchClientData = async ({ clientAlias, containers }) => {
   }));
 
   return {
-    Alias,
+    ClientAlias: Alias,
     ClientID: id,
     ShortName,
     LongName,
@@ -26,6 +28,23 @@ const fetchClientData = async ({ clientAlias, containers }) => {
     clientPages,
     clientProducts: Applications,
     clientAreas: filteredAreas,
+  };
+};
+
+const fetchClientData = async ({ ClientAlias, containers }) => {
+  const clientData: any = await queryClientDB({
+    ClientAlias,
+    containers,
+  });
+
+  const { ClientID } = clientData;
+
+  const sitemapGroups = await fetchSitemap();
+
+  return {
+    ID: ClientID,
+    sitemapGroups,
+    ...clientData,
   };
 };
 

--- a/src/utils/getActiveToggle/index.ts
+++ b/src/utils/getActiveToggle/index.ts
@@ -1,5 +1,5 @@
 const getActiveToggle = (toggles, toggleKey, defaultValue = null) => {
-  const toggle = toggles.find(({ key }) => key === toggleKey);
+  const toggle = (toggles || []).find(({ key }) => key === toggleKey);
 
   if (!toggle) return defaultValue;
 

--- a/src/utils/pageUtils.ts
+++ b/src/utils/pageUtils.ts
@@ -1,14 +1,8 @@
-import PageMappings from '../layouts';
 import filter from 'lodash/filter';
-import has from 'lodash/has';
 
 export const pathParts = (path: string) => {
   const REGEX = /^\/?(?<clientAlias>[^\/]+)\/?(?<pageAlias>[^\/]+)?\/?/;
   return path.match(REGEX).groups;
-};
-
-export const IsNextPage = path => {
-  return has(PageMappings(), pathParts(path.split('?')[0]).pageAlias);
 };
 
 const amI = param => (navNodes, currentPageAlias) =>

--- a/src/utils/pageUtils.ts
+++ b/src/utils/pageUtils.ts
@@ -1,4 +1,4 @@
-import { NextPages } from '../pages/[clientAlias]/[handle]';
+import PageMappings from '../layouts';
 import filter from 'lodash/filter';
 import has from 'lodash/has';
 
@@ -8,7 +8,7 @@ export const pathParts = (path: string) => {
 };
 
 export const IsNextPage = path => {
-  return has(NextPages, pathParts(path.split('?')[0]).pageAlias);
+  return has(PageMappings(), pathParts(path.split('?')[0]).pageAlias);
 };
 
 const amI = param => (navNodes, currentPageAlias) =>

--- a/src/utils/useEntityText/index.ts
+++ b/src/utils/useEntityText/index.ts
@@ -1,8 +1,8 @@
-import { Context } from '../context';
+import { PageContext } from '../context';
 import { useContext } from 'react';
 
 const useEntityText = key => {
-  const { entities } = useContext(Context);
+  const { entities } = useContext(PageContext);
 
   if (!entities) return null;
 


### PR DESCRIPTION
Uses separate contexts (Client & Page) to simplify prop handling, and adds type annotations so we don't need to fill out the full object unless required.

Also adds `production` and `dev` arrays to `layouts`, to enable testing of pages in dev / staging without affecting links in production.